### PR TITLE
changed the format of the day, month

### DIFF
--- a/harvest.js
+++ b/harvest.js
@@ -81,8 +81,8 @@ function getDate() {
 
   const formats = [
     { year: "numeric" },
-    { month: "numeric" },
-    { day: "numeric" },
+    { month: "2-digit" },
+    { day: "2-digit" },
   ];
   return join(new Date(), formats, "-");
 }


### PR DESCRIPTION
### i just changed the format of the date that we sent to harvest
the month and day should have 2 digits, so it should be `2022-05-01` instead of `2022-5-1`

ref:
https://help.getharvest.com/api-v2/timesheets-api/timesheets/time-entries/#create-a-time-entry-via-duration